### PR TITLE
Allow this crate to be used in no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,9 @@ repository = "https://github.com/pyfisch/keyboard-types"
 keywords = ["keyboard", "input", "event", "webdriver"]
 
 [features]
-default = ["serde", "webdriver"]
-webdriver = ["unicode-segmentation"]
+default = ["serde", "webdriver", "std"]
+std = []
+webdriver = ["unicode-segmentation", "std"]
 
 [dependencies]
 bitflags = "1.0.0"

--- a/convert.py
+++ b/convert.py
@@ -47,8 +47,12 @@ def convert_key(text, file):
     print("""
 // AUTO GENERATED CODE - DO NOT EDIT
 
-use std::fmt::{self, Display};
-use std::str::FromStr;
+use core::fmt::{self, Display};
+use core::str::FromStr;
+
+use alloc::string::{String, ToString};
+
+#[cfg(feature = "std")]
 use std::error::Error;
 
 /// Key represents the meaning of a keypress.
@@ -114,6 +118,7 @@ impl fmt::Display for UnrecognizedKeyError {
     }
 }
 
+#[cfg(feature = "std")]
 impl Error for UnrecognizedKeyError {}
 
 /// Check if string can be used as a `Key::Character` _keystring_.
@@ -142,8 +147,10 @@ def convert_code(text, file):
     print("""
 // AUTO GENERATED CODE - DO NOT EDIT
 
-use std::fmt::{self, Display};
-use std::str::FromStr;
+use core::fmt::{self, Display};
+use core::str::FromStr;
+
+#[cfg(feature = "std")]
 use std::error::Error;
 
 /// Code is the physical position of a key.
@@ -242,6 +249,7 @@ impl fmt::Display for UnrecognizedCodeError {
     }
 }
 
+#[cfg(feature = "std")]
 impl Error for UnrecognizedCodeError {}
     """, file=file)
 

--- a/src/code.rs
+++ b/src/code.rs
@@ -1,8 +1,10 @@
 
 // AUTO GENERATED CODE - DO NOT EDIT
 
-use std::fmt::{self, Display};
-use std::str::FromStr;
+use core::fmt::{self, Display};
+use core::str::FromStr;
+
+#[cfg(feature = "std")]
 use std::error::Error;
 
 /// Code is the physical position of a key.
@@ -878,5 +880,6 @@ impl fmt::Display for UnrecognizedCodeError {
     }
 }
 
+#[cfg(feature = "std")]
 impl Error for UnrecognizedCodeError {}
     

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,8 +1,12 @@
 
 // AUTO GENERATED CODE - DO NOT EDIT
 
-use std::fmt::{self, Display};
-use std::str::FromStr;
+use core::fmt::{self, Display};
+use core::str::FromStr;
+
+use alloc::string::{String, ToString};
+
+#[cfg(feature = "std")]
 use std::error::Error;
 
 /// Key represents the meaning of a keypress.
@@ -1270,6 +1274,7 @@ impl fmt::Display for UnrecognizedKeyError {
     }
 }
 
+#[cfg(feature = "std")]
 impl Error for UnrecognizedKeyError {}
 
 /// Check if string can be used as a `Key::Character` _keystring_.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,15 @@
 //! but this crate should be useful for anyone implementing keyboard
 //! input in a cross-platform way.
 
-use std::fmt;
+#![no_std]
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
+
+use alloc::string::String;
+use core::fmt;
 
 pub use code::{Code, UnrecognizedCodeError};
 pub use key::{Key, UnrecognizedKeyError};

--- a/src/webdriver.rs
+++ b/src/webdriver.rs
@@ -41,7 +41,10 @@
 //!
 //! Specification: https://w3c.github.io/webdriver/
 
+use std::borrow::ToOwned;
 use std::collections::HashSet;
+use std::string::{String, ToString};
+use std::vec::Vec;
 
 use unicode_segmentation::UnicodeSegmentation;
 


### PR DESCRIPTION
Resolves #17  by implementing initial `no_std` support. **This is a breaking change.** I did not implement `no_alloc` because it would require a substantial change to the codebase.