### PR TITLE
Update build status, remove Cargo.toml badge.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,3 @@ webdriver = ["unicode-segmentation"]
 bitflags = "1.0.0"
 serde = { version = "1.0.0", optional = true, features = ["derive"] }
 unicode-segmentation = { version = "1.2.0", optional = true }
-
-[badges]
-travis-ci = { repository = "pyfisch/keyboard-types" }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Keyboard Types
 ==============
-[![Build Status](https://travis-ci.org/pyfisch/keyboard-types.svg?branch=master)](https://travis-ci.org/pyfisch/keyboard-types)
+
+[![Build Status](https://github.com/pyfisch/keyboard-types/actions/workflows/ci.yml/badge.svg)](https://github.com/pyfisch/keyboard-types/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/keyboard-types.svg)](https://crates.io/crates/keyboard-types)
 [![Documentation](https://docs.rs/keyboard-types/badge.svg)](https://docs.rs/keyboard-types)
 


### PR DESCRIPTION
The badges section of a Cargo.toml no longer needs build status badges as they are no longer supported by crates.io.