### PR TITLE
Use SPDX 2.1 license expression.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.6.2"
 authors = ["Pyfisch <pyfisch@posteo.org>"]
 description = "Contains types to define keyboard related events."
 readme = "README.md"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/pyfisch/keyboard-types"
 keywords = ["keyboard", "input", "event", "webdriver"]
 


### PR DESCRIPTION
This improves the usage of automated tooling which consumes the license information.