### PR TITLE
Set rust-version (MSRV) to 1.56.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/pyfisch/keyboard-types"
 keywords = ["keyboard", "input", "event", "webdriver"]
+rust-version = "1.56"
 
 [features]
 default = ["serde", "webdriver"]


### PR DESCRIPTION
This is the earliest version that compiles as transitive deps require this.