### PR TITLE
Update to Rust edition 2018.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/pyfisch/keyboard-types"
 keywords = ["keyboard", "input", "event", "webdriver"]
+edition = "2018"
 rust-version = "1.56"
 
 [features]

--- a/convert.py
+++ b/convert.py
@@ -56,7 +56,7 @@ use std::error::Error;
 /// Specification:
 /// <https://w3c.github.io/uievents-key/>
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum Key {
     /// A key string that corresponds to the character typed by the user,
@@ -94,7 +94,7 @@ impl FromStr for Key {
     type Err = UnrecognizedKeyError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use Key::*;
+        use crate::Key::*;
         match s {
             s if is_key_string(s) => Ok(Character(s.to_string())),""", file=file)
     print_from_str_entries(display, file)
@@ -155,7 +155,7 @@ use std::error::Error;
 /// Specification:
 /// <https://w3c.github.io/uievents-code/>
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum Code {""", file=file)
     display = parse(text)
@@ -224,7 +224,7 @@ impl FromStr for Code {
     type Err = UnrecognizedCodeError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use Code::*;
+        use crate::Code::*;
         match s {""", file=file)
     print_from_str_entries(display, file)
     print("""

--- a/src/code.rs
+++ b/src/code.rs
@@ -14,7 +14,7 @@ use std::error::Error;
 /// Specification:
 /// <https://w3c.github.io/uievents-code/>
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum Code {
     /// <code class="keycap">`~</code> on a US keyboard. This is the <code class="keycap">半角/全角/漢字</code> (<span class="unicode">hankaku/zenkaku/kanji</span>) key on Japanese keyboards
@@ -657,7 +657,7 @@ impl FromStr for Code {
     type Err = UnrecognizedCodeError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use Code::*;
+        use crate::Code::*;
         match s {
             "Backquote" => Ok(Backquote),
             "Backslash" => Ok(Backslash),

--- a/src/key.rs
+++ b/src/key.rs
@@ -10,7 +10,7 @@ use std::error::Error;
 /// Specification:
 /// <https://w3c.github.io/uievents-key/>
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum Key {
     /// A key string that corresponds to the character typed by the user,
@@ -955,7 +955,7 @@ impl FromStr for Key {
     type Err = UnrecognizedKeyError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use Key::*;
+        use crate::Key::*;
         match s {
             s if is_key_string(s) => Ok(Character(s.to_string())),
             "Unidentified" => Ok(Unidentified),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,19 +6,11 @@
 
 use std::fmt;
 
-pub use code::{Code, UnrecognizedCodeError};
-pub use key::{Key, UnrecognizedKeyError};
-pub use location::Location;
-pub use modifiers::Modifiers;
-pub use shortcuts::ShortcutMatcher;
-
-#[macro_use]
-extern crate bitflags;
-#[cfg(feature = "serde")]
-#[macro_use]
-extern crate serde;
-#[cfg(feature = "webdriver")]
-extern crate unicode_segmentation;
+pub use crate::code::{Code, UnrecognizedCodeError};
+pub use crate::key::{Key, UnrecognizedKeyError};
+pub use crate::location::Location;
+pub use crate::modifiers::Modifiers;
+pub use crate::shortcuts::ShortcutMatcher;
 
 mod code;
 mod key;
@@ -27,6 +19,9 @@ mod modifiers;
 mod shortcuts;
 #[cfg(feature = "webdriver")]
 pub mod webdriver;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Describes the state the key is in.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]

--- a/src/location.rs
+++ b/src/location.rs
@@ -1,7 +1,7 @@
 /// The location attribute contains an indication of the logical location
 /// of the key on the device.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Location {
     /// The key activation MUST NOT be distinguished as the left or right
     /// version of the key, and (other than the NumLock key) did not

--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -5,13 +5,13 @@
 //!
 //! Use the constants to match for combinations of the modifier keys.
 
-bitflags! {
+bitflags::bitflags! {
     /// Pressed modifier keys.
     ///
     /// Specification:
     /// <https://w3c.github.io/uievents-key/#keys-modifier>
     #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct Modifiers: u32 {
         const ALT = 0x01;
         const ALT_GRAPH = 0x2;

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -1,4 +1,4 @@
-use {Key, KeyState, KeyboardEvent, Modifiers};
+use crate::{Key, KeyState, KeyboardEvent, Modifiers};
 
 /// Match keyboard shortcuts and excute actions.
 ///

--- a/src/webdriver.rs
+++ b/src/webdriver.rs
@@ -45,9 +45,9 @@ use std::collections::HashSet;
 
 use unicode_segmentation::UnicodeSegmentation;
 
-use first_char;
-use {Code, Key, KeyState, KeyboardEvent, Location, Modifiers};
-use {CompositionEvent, CompositionState};
+use crate::first_char;
+use crate::{Code, Key, KeyState, KeyboardEvent, Location, Modifiers};
+use crate::{CompositionEvent, CompositionState};
 
 // Spec: <https://w3c.github.io/webdriver/#keyboard-actions>
 // normalised (sic) as in british spelling
@@ -276,7 +276,7 @@ fn get_modifier(key: &Key) -> Modifiers {
 ///
 /// Spec: <https://w3c.github.io/webdriver/#dfn-key-input-state>
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyInputState {
     pressed: HashSet<Key>,
     modifiers: Modifiers,
@@ -373,7 +373,7 @@ impl KeyInputState {
 ///
 /// Returned by the `send_keys` function.
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Event {
     Keyboard(KeyboardEvent),
     Composition(CompositionEvent),


### PR DESCRIPTION
This leaves `extern crate` usage which can be removed in subsequent commits.