### PR TITLE
deps: Update to bitflags 2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,10 @@ rust-version = "1.56"
 
 [features]
 default = ["serde", "webdriver"]
+serde = ["dep:serde", "bitflags/serde"]
 webdriver = ["unicode-segmentation"]
 
 [dependencies]
-bitflags = "1.0.0"
+bitflags = "2"
 serde = { version = "1.0.0", optional = true, features = ["derive"] }
 unicode-segmentation = { version = "1.2.0", optional = true }

--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -10,7 +10,7 @@ bitflags! {
     ///
     /// Specification:
     /// <https://w3c.github.io/uievents-key/#keys-modifier>
-    #[derive(Default)]
+    #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     pub struct Modifiers: u32 {
         const ALT = 0x01;


### PR DESCRIPTION
This requires enabling a "serde" feature when the `keyboard-types` "serde" feature is enabled.