### PR TITLE
ci: Check MSRV, bump to 1.60 and improve feature coverage.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,21 +3,26 @@ on: [push, pull_request]
 name: Continuous integration
 
 jobs:
-  check:
-    name: Check
+  check-test:
+    name: Check and test crate
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - "1.60"
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          components: clippy
+      # Default features
       - run: cargo check --all-targets
-
-  test:
-    name: Test Suite
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
       - run: cargo test
+      # No default features
+      - run: cargo check --all-targets --no-default-features
+      - run: cargo test --no-default-features
 
   clippy-fmt:
     name: Run Clippy and format code

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/pyfisch/keyboard-types"
 keywords = ["keyboard", "input", "event", "webdriver"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [features]
 default = ["serde", "webdriver"]


### PR DESCRIPTION
This also combines the jobs into one since they run quickly and this reduces the overhead of installing deps for each step.