### PR TITLE
ci: Update to `actions/checkout@v4` from v3.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           - stable
           - "1.60"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -27,7 +27,7 @@ jobs:
     name: Run Clippy and format code
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt


### PR DESCRIPTION
This mainly keeps up with the current version of Node within the GitHub Actions infrastructure.