### PR TITLE
Slight HTML parsing

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -17,6 +17,9 @@ def parse(text):
                 continue
             # Use the semantic `<kbd>` element instead.
             line = re.sub(r"<code class=\"keycap\">(.*?)</code>", r"<kbd>\1</kbd>", line)
+            # Link to the relevant type.
+            line = re.sub(r"<code class=\"code\">\"(.*?)\"</code>", r"[`\1`][Code::\1]", line)
+            line = re.sub(r"<code class=\"key\">\"(.*?)\"</code>", r"[`\1`][Key::\1]", line)
             doc_comment += "    /// {}\n".format(line)
         display.append([match[0], doc_comment, []])
     return display

--- a/src/code.rs
+++ b/src/code.rs
@@ -179,7 +179,7 @@ pub enum Code {
     NonConvert,
     /// <kbd>⌦</kbd>. The forward delete key.
     /// Note that on Apple keyboards, the key labelled <kbd>Delete</kbd> on the main part of
-    /// the keyboard should be encoded as <code class="code">"Backspace"</code>.
+    /// the keyboard should be encoded as [`Backspace`][Code::Backspace].
     Delete,
     /// <kbd>End</kbd> or <kbd>↘</kbd>
     End,
@@ -201,7 +201,7 @@ pub enum Code {
     ArrowRight,
     /// <kbd>↑</kbd>
     ArrowUp,
-    /// On the Mac, the <code class="code">"NumLock"</code> code should be used for the numpad <kbd>Clear</kbd> key.
+    /// On the Mac, the [`NumLock`][Code::NumLock] code should be used for the numpad <kbd>Clear</kbd> key.
     NumLock,
     /// <kbd>0 Ins</kbd> on a keyboard<br><kbd>0</kbd> on a phone or remote control
     Numpad0,
@@ -231,7 +231,7 @@ pub enum Code {
     /// Found on the Microsoft Natural Keyboard.
     NumpadBackspace,
     /// <kbd>C</kbd> or <kbd>AC</kbd> (All Clear). Also for use with numpads that have a <kbd>Clear</kbd> key that is separate from the <kbd>NumLock</kbd> key. On the Mac, the numpad <kbd>Clear</kbd> key should always
-    /// be encoded as <code class="code">"NumLock"</code>.
+    /// be encoded as [`NumLock`][Code::NumLock].
     NumpadClear,
     /// <kbd>CE</kbd> (Clear Entry)
     NumpadClearEntry,
@@ -260,7 +260,7 @@ pub enum Code {
     /// <kbd>M-</kbd> Subtract current entry from the value stored in memory.
     NumpadMemorySubtract,
     /// <kbd>*</kbd> on a keyboard. For use with numpads that provide mathematical
-    /// operations (<kbd>+</kbd>, <kbd>-</kbd>, <kbd>*</kbd> and <kbd>/</kbd>).<br>Use <code class="code">"NumpadStar"</code> for the <kbd>*</kbd> key on phones and remote controls.
+    /// operations (<kbd>+</kbd>, <kbd>-</kbd>, <kbd>*</kbd> and <kbd>/</kbd>).<br>Use [`NumpadStar`][Code::NumpadStar] for the <kbd>*</kbd> key on phones and remote controls.
     NumpadMultiply,
     /// <kbd>(</kbd> Found on the Microsoft Natural Keyboard.
     NumpadParenLeft,
@@ -268,7 +268,7 @@ pub enum Code {
     NumpadParenRight,
     /// <kbd>*</kbd> on a phone or remote control device.
     /// This key is typically found below the <kbd>7</kbd> key and to the left of
-    /// the <kbd>0</kbd> key.<br>Use <code class="code">"NumpadMultiply"</code> for the <kbd>*</kbd> key on
+    /// the <kbd>0</kbd> key.<br>Use [`NumpadMultiply`][Code::NumpadMultiply] for the <kbd>*</kbd> key on
     /// numeric keypads.
     NumpadStar,
     /// <kbd>-</kbd>

--- a/src/key.rs
+++ b/src/key.rs
@@ -72,7 +72,7 @@ pub enum Key {
     ArrowUp,
     /// The End key, used with keyboard entry to go to the end of content (<code class="android">KEYCODE_MOVE_END</code>).
     End,
-    /// The Home key, used with keyboard entry, to go to start of content (<code class="android">KEYCODE_MOVE_HOME</code>).<br> For the mobile phone <kbd>Home</kbd> key (which goes to the phone’s main screen), use <code class="key">"GoHome"</code>.
+    /// The Home key, used with keyboard entry, to go to start of content (<code class="android">KEYCODE_MOVE_HOME</code>).<br> For the mobile phone <kbd>Home</kbd> key (which goes to the phone’s main screen), use [`GoHome`][Key::GoHome].
     Home,
     /// The Page Down key, to scroll down or display next page of content.
     PageDown,
@@ -126,10 +126,10 @@ pub enum Key {
     /// Open a help dialog or toggle display of help information. (<code class="appcommand"><code class="appcommand">APPCOMMAND_HELP</code></code>, <code class="android"><code class="android">KEYCODE_HELP</code></code>)
     Help,
     /// Pause the current state or application (as appropriate).
-    /// <p class="note" role="note">Do not use this value for the <kbd>Pause</kbd> button on media controllers. Use <code class="key">"MediaPause"</code> instead.</p>
+    /// <p class="note" role="note">Do not use this value for the <kbd>Pause</kbd> button on media controllers. Use [`MediaPause`][Key::MediaPause] instead.</p>
     Pause,
     /// Play or resume the current state or application (as appropriate).
-    /// <p class="note" role="note">Do not use this value for the <kbd>Play</kbd> button on media controllers. Use <code class="key">"MediaPlay"</code> instead.</p>
+    /// <p class="note" role="note">Do not use this value for the <kbd>Play</kbd> button on media controllers. Use [`MediaPlay`][Key::MediaPlay] instead.</p>
     Play,
     /// The properties (Props) key.
     Props,
@@ -255,7 +255,7 @@ pub enum Key {
     /// Initiate or continue forward playback at faster than normal speed, or increase speed if already fast forwarding. (<code class="appcommand"><code class="appcommand">APPCOMMAND_MEDIA_FAST_FORWARD</code></code>, <code class="android"><code class="android">KEYCODE_MEDIA_FAST_FORWARD</code></code>)
     MediaFastForward,
     /// Pause the currently playing media. (<code class="appcommand"><code class="appcommand">APPCOMMAND_MEDIA_PAUSE</code></code>, <code class="android"><code class="android">KEYCODE_MEDIA_PAUSE</code></code>)
-    /// <p class="note" role="note">Media controller devices should use this value rather than <code class="key">"Pause"</code> for their pause keys.</p>
+    /// <p class="note" role="note">Media controller devices should use this value rather than [`Pause`][Key::Pause] for their pause keys.</p>
     MediaPause,
     /// Initiate or continue media playback at normal speed, if not currently playing at normal speed. (<code class="appcommand"><code class="appcommand">APPCOMMAND_MEDIA_PLAY</code></code>, <code class="android"><code class="android">KEYCODE_MEDIA_PLAY</code></code>)
     MediaPlay,
@@ -518,7 +518,7 @@ pub enum Key {
     /// Lock or unlock current content or program. (<code class="vk">VK_LOCK</code>)
     Lock,
     /// Show a list of media applications: audio/video players and image viewers. (<code class="vk">VK_APPS</code>)
-    /// <p class="note" role="note">Do not confuse this key value with the Windows' <code class="vk"><code class="vk">VK_APPS</code></code> / <code class="vk"><code class="vk">VK_CONTEXT_MENU</code></code> key, which is encoded as <code class="key">"ContextMenu"</code>.</p>
+    /// <p class="note" role="note">Do not confuse this key value with the Windows' <code class="vk"><code class="vk">VK_APPS</code></code> / <code class="vk"><code class="vk">VK_CONTEXT_MENU</code></code> key, which is encoded as [`ContextMenu`][Key::ContextMenu].</p>
     MediaApps,
     /// Audio track key. (<code class="android">KEYCODE_MEDIA_AUDIO_TRACK</code>)
     MediaAudioTrack,


### PR DESCRIPTION
Use the semantic tag `<kbd>` for keycaps and link to types when possible.

Before:
<img width="572" alt="before" src="https://github.com/user-attachments/assets/ff58f92f-b47d-418a-a5ba-20463f8377ff">

After:
<img width="566" alt="after" src="https://github.com/user-attachments/assets/7e1c0975-e4c3-41ee-9910-90c30724d837">
