### PR TITLE
Mark legacy modifier keys and codes as deprecated

### DIFF
--- a/src/code.rs
+++ b/src/code.rs
@@ -2,6 +2,7 @@
 // AUTO GENERATED CODE - DO NOT EDIT
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(clippy::doc_markdown)]
+#![allow(deprecated)]
 
 use std::fmt::{self, Display};
 use std::str::FromStr;
@@ -321,8 +322,11 @@ pub enum Code {
     AudioVolumeMute,
     AudioVolumeUp,
     WakeUp,
+    #[deprecated = "marked as legacy in the spec, use Meta instead"]
     Hyper,
+    #[deprecated = "marked as legacy in the spec, use Meta instead"]
     Super,
+    #[deprecated = "marked as legacy in the spec, use Meta instead"]
     Turbo,
     Abort,
     Resume,

--- a/src/key.rs
+++ b/src/key.rs
@@ -2,6 +2,7 @@
 // AUTO GENERATED CODE - DO NOT EDIT
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(clippy::doc_markdown)]
+#![allow(deprecated)]
 
 use std::fmt::{self, Display};
 use std::str::FromStr;
@@ -56,8 +57,10 @@ pub enum Key {
     /// The Symbol Lock key.
     SymbolLock,
     /// The <kbd>Hyper</kbd> key.
+    #[deprecated = "marked as legacy in the spec, use Meta instead"]
     Hyper,
     /// The <kbd>Super</kbd> key.
+    #[deprecated = "marked as legacy in the spec, use Meta instead"]
     Super,
     /// The <kbd>Enter</kbd> or <kbd>↵</kbd> key, to activate current selection or accept current input.<br/> This key value is also used for the <kbd>Return</kbd> (Macintosh numpad) key.<br/> This key value is also used for the Android <code class="android">KEYCODE_DPAD_CENTER</code>.
     Enter,

--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -25,7 +25,9 @@ bitflags::bitflags! {
         const SHIFT = 0x200;
         const SYMBOL = 0x400;
         const SYMBOL_LOCK = 0x800;
+        #[deprecated = "marked as legacy in the spec, use META instead"]
         const HYPER = 0x1000;
+        #[deprecated = "marked as legacy in the spec, use META instead"]
         const SUPER = 0x2000;
     }
 }

--- a/src/webdriver.rs
+++ b/src/webdriver.rs
@@ -424,6 +424,7 @@ impl From<CompositionEvent> for Event {
 ///
 /// Spec: <https://w3c.github.io/webdriver/#element-send-keys>
 pub fn send_keys(text: &str) -> Vec<Event> {
+    #[allow(deprecated)]
     fn is_modifier(text: &str) -> bool {
         if text.chars().count() != 1 {
             return false;


### PR DESCRIPTION
This resolves my concern with `Meta` vs. `Super` from https://github.com/pyfisch/keyboard-types/issues/19.