### PR TITLE
Separate `Key` into `Character` and `NamedKey`

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -42,7 +42,7 @@ def parse(text):
                 code.replace_with(f"[`{text}`][Code::{text}]")
             for code in typical_usage.find_all(class_='key'):
                 text = code.text.strip().strip('"')
-                code.replace_with(f"[`{text}`][Key::{text}]")
+                code.replace_with(f"[`{text}`][NamedKey::{text}]")
 
             comment = re.sub(r"[ \t][ \t]+", "\n", typical_usage.decode_contents())
 
@@ -106,15 +106,10 @@ use std::error::Error;
 ///
 /// Specification:
 /// <https://w3c.github.io/uievents-key/>
-#[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
-pub enum Key {
-    /// A key string that corresponds to the character typed by the user,
-    /// taking into account the user’s current locale setting, modifier state,
-    /// and any system-level keyboard mapping overrides that are in effect.
-    Character(String),
-    """, file=file)
+pub enum NamedKey {""", file=file)
     display = parse(text)
 
     for i in range(1, 36):
@@ -130,64 +125,40 @@ pub enum Key {
 
     print("""
 
-impl Display for Key {
+impl Display for NamedKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::Key::*;
-        match *self {
-            Character(ref s) => write!(f, "{}", s),
-    """, file=file)
+        use self::NamedKey::*;
+        match *self {""", file=file)
     print_display_entries(display, file)
     print("""
         }
     }
 }
 
-impl FromStr for Key {
-    type Err = UnrecognizedKeyError;
+impl FromStr for NamedKey {
+    type Err = UnrecognizedNamedKeyError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use crate::Key::*;
-        match s {
-            s if is_key_string(s) => Ok(Character(s.to_string())),""", file=file)
+        use crate::NamedKey::*;
+        match s {""", file=file)
     print_from_str_entries(display, file)
     print("""
-            _ => Err(UnrecognizedKeyError),
+            _ => Err(UnrecognizedNamedKeyError),
         }
     }
 }
 
 /// Parse from string error, returned when string does not match to any Key variant.
 #[derive(Clone, Debug)]
-pub struct UnrecognizedKeyError;
+pub struct UnrecognizedNamedKeyError;
 
-impl fmt::Display for UnrecognizedKeyError {
+impl fmt::Display for UnrecognizedNamedKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Unrecognized key")
     }
 }
 
-impl Error for UnrecognizedKeyError {}
-
-/// Check if string can be used as a `Key::Character` _keystring_.
-///
-/// This check is simple and is meant to prevents common mistakes like mistyped keynames
-/// (e.g. `Ennter`) from being recognized as characters.
-fn is_key_string(s: &str) -> bool {
-    s.chars().all(|c| !c.is_control()) && s.chars().skip(1).all(|c| !c.is_ascii())
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_is_key_string() {
-        assert!(is_key_string("A"));
-        assert!(!is_key_string("AA"));
-        assert!(!is_key_string("\t"));
-    }
-}
-    """, file=file)
+impl Error for UnrecognizedNamedKeyError {}""", file=file)
 
 
 def convert_code(text, file):
@@ -273,8 +244,7 @@ pub enum Code {""", file=file)
 impl Display for Code {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::Code::*;
-        match *self {
-    """, file=file)
+        match *self {""", file=file)
     print_display_entries(display, file)
     print("""
         }
@@ -304,13 +274,12 @@ impl fmt::Display for UnrecognizedCodeError {
     }
 }
 
-impl Error for UnrecognizedCodeError {}
-    """, file=file)
+impl Error for UnrecognizedCodeError {}""", file=file)
 
 
 if __name__ == '__main__':
     input = requests.get('https://w3c.github.io/uievents-key/').text
-    with open('src/key.rs', 'w', encoding='utf-8') as output:
+    with open('src/named_key.rs', 'w', encoding='utf-8') as output:
         convert_key(input, output)
     input = requests.get('https://w3c.github.io/uievents-code/').text
     with open('src/code.rs', 'w', encoding='utf-8') as output:

--- a/src/code.rs
+++ b/src/code.rs
@@ -475,7 +475,6 @@ impl Display for Code {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::Code::*;
         match *self {
-    
             Backquote => f.write_str("Backquote"),
             Backslash => f.write_str("Backslash"),
             BracketLeft => f.write_str("BracketLeft"),
@@ -936,4 +935,3 @@ impl fmt::Display for UnrecognizedCodeError {
 }
 
 impl Error for UnrecognizedCodeError {}
-    

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,16 +6,19 @@
 
 #![warn(clippy::doc_markdown)]
 
+use core::fmt;
+use core::str::FromStr;
+
 pub use crate::code::{Code, UnrecognizedCodeError};
-pub use crate::key::{Key, UnrecognizedKeyError};
 pub use crate::location::Location;
 pub use crate::modifiers::Modifiers;
+pub use crate::named_key::{NamedKey, UnrecognizedNamedKeyError};
 pub use crate::shortcuts::ShortcutMatcher;
 
 mod code;
-mod key;
 mod location;
 mod modifiers;
+mod named_key;
 mod shortcuts;
 #[cfg(feature = "webdriver")]
 pub mod webdriver;
@@ -149,6 +152,44 @@ pub struct CompositionEvent {
     pub data: String,
 }
 
+/// The value recieved from the keypress.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum Key {
+    /// A key string that corresponds to the character typed by the user,
+    /// taking into account the user’s current locale setting, modifier state,
+    /// and any system-level keyboard mapping overrides that are in effect.
+    Character(String),
+    Named(NamedKey),
+}
+
+/// Parse from string error, returned when string does not match to any Key variant.
+#[derive(Clone, Debug)]
+pub struct UnrecognizedKeyError;
+
+impl fmt::Display for Key {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Character(s) => f.write_str(s),
+            Self::Named(k) => k.fmt(f),
+        }
+    }
+}
+
+impl FromStr for Key {
+    type Err = UnrecognizedKeyError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if is_key_string(s) {
+            Ok(Self::Character(s.to_string()))
+        } else {
+            Ok(Self::Named(
+                NamedKey::from_str(s).map_err(|_| UnrecognizedKeyError)?,
+            ))
+        }
+    }
+}
+
 impl Key {
     /// Determine a *charCode* value for a key with a character value.
     ///
@@ -161,7 +202,7 @@ impl Key {
         // otherwise 0
         match self {
             Key::Character(ref c) => c.chars().next().unwrap_or('\0') as u32,
-            _ => 0,
+            Key::Named(_) => 0,
         }
     }
 
@@ -173,23 +214,23 @@ impl Key {
     pub fn legacy_keycode(&self) -> u32 {
         match self {
             // See: https://w3c.github.io/uievents/#fixed-virtual-key-codes
-            Key::Backspace => 8,
-            Key::Tab => 9,
-            Key::Enter => 13,
-            Key::Shift => 16,
-            Key::Control => 17,
-            Key::Alt => 18,
-            Key::CapsLock => 20,
-            Key::Escape => 27,
-            Key::PageUp => 33,
-            Key::PageDown => 34,
-            Key::End => 35,
-            Key::Home => 36,
-            Key::ArrowLeft => 37,
-            Key::ArrowUp => 38,
-            Key::ArrowRight => 39,
-            Key::ArrowDown => 40,
-            Key::Delete => 46,
+            Key::Named(NamedKey::Backspace) => 8,
+            Key::Named(NamedKey::Tab) => 9,
+            Key::Named(NamedKey::Enter) => 13,
+            Key::Named(NamedKey::Shift) => 16,
+            Key::Named(NamedKey::Control) => 17,
+            Key::Named(NamedKey::Alt) => 18,
+            Key::Named(NamedKey::CapsLock) => 20,
+            Key::Named(NamedKey::Escape) => 27,
+            Key::Named(NamedKey::PageUp) => 33,
+            Key::Named(NamedKey::PageDown) => 34,
+            Key::Named(NamedKey::End) => 35,
+            Key::Named(NamedKey::Home) => 36,
+            Key::Named(NamedKey::ArrowLeft) => 37,
+            Key::Named(NamedKey::ArrowUp) => 38,
+            Key::Named(NamedKey::ArrowRight) => 39,
+            Key::Named(NamedKey::ArrowDown) => 40,
+            Key::Named(NamedKey::Delete) => 46,
             Key::Character(ref c) if c.len() == 1 => match first_char(c) {
                 ' ' => 32,
                 x @ '0'..='9' => x as u32,
@@ -221,8 +262,14 @@ impl Default for KeyState {
 }
 
 impl Default for Key {
-    fn default() -> Key {
-        Key::Unidentified
+    fn default() -> Self {
+        Self::Named(NamedKey::default())
+    }
+}
+
+impl Default for NamedKey {
+    fn default() -> Self {
+        Self::Unidentified
     }
 }
 
@@ -244,4 +291,24 @@ impl Default for Location {
 /// Panics if the string is empty.
 fn first_char(s: &str) -> char {
     s.chars().next().expect("empty string")
+}
+
+/// Check if string can be used as a `Key::Character` _keystring_.
+///
+/// This check is simple and is meant to prevents common mistakes like mistyped keynames
+/// (e.g. `Ennter`) from being recognized as characters.
+fn is_key_string(s: &str) -> bool {
+    s.chars().all(|c| !c.is_control()) && s.chars().skip(1).all(|c| !c.is_ascii())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_is_key_string() {
+        assert!(is_key_string("A"));
+        assert!(!is_key_string("AA"));
+        assert!(!is_key_string("	"));
+    }
 }

--- a/src/named_key.rs
+++ b/src/named_key.rs
@@ -12,15 +12,10 @@ use std::error::Error;
 ///
 /// Specification:
 /// <https://w3c.github.io/uievents-key/>
-#[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
-pub enum Key {
-    /// A key string that corresponds to the character typed by the user,
-    /// taking into account the user’s current locale setting, modifier state,
-    /// and any system-level keyboard mapping overrides that are in effect.
-    Character(String),
-
+pub enum NamedKey {
     /// This key value is used when an implementation is unable to
     /// identify another key value, due to either hardware,
     /// platform, or software constraints.
@@ -76,7 +71,7 @@ pub enum Key {
     ArrowUp,
     /// The End key, used with keyboard entry to go to the end of content (<code class="android">KEYCODE_MOVE_END</code>).
     End,
-    /// The Home key, used with keyboard entry, to go to start of content (<code class="android">KEYCODE_MOVE_HOME</code>).<br/> For the mobile phone <kbd>Home</kbd> key (which goes to the phone’s main screen), use [`GoHome`][Key::GoHome].
+    /// The Home key, used with keyboard entry, to go to start of content (<code class="android">KEYCODE_MOVE_HOME</code>).<br/> For the mobile phone <kbd>Home</kbd> key (which goes to the phone’s main screen), use [`GoHome`][NamedKey::GoHome].
     Home,
     /// The Page Down key, to scroll down or display next page of content.
     PageDown,
@@ -130,10 +125,10 @@ pub enum Key {
     /// Open a help dialog or toggle display of help information. (<code class="appcommand"><code class="appcommand">APPCOMMAND_HELP</code></code>, <code class="android"><code class="android">KEYCODE_HELP</code></code>)
     Help,
     /// Pause the current state or application (as appropriate).
-    /// <p class="note" role="note">Do not use this value for the <kbd>Pause</kbd> button on media controllers. Use [`MediaPause`][Key::MediaPause] instead.</p>
+    /// <p class="note" role="note">Do not use this value for the <kbd>Pause</kbd> button on media controllers. Use [`MediaPause`][NamedKey::MediaPause] instead.</p>
     Pause,
     /// Play or resume the current state or application (as appropriate).
-    /// <p class="note" role="note">Do not use this value for the <kbd>Play</kbd> button on media controllers. Use [`MediaPlay`][Key::MediaPlay] instead.</p>
+    /// <p class="note" role="note">Do not use this value for the <kbd>Play</kbd> button on media controllers. Use [`MediaPlay`][NamedKey::MediaPlay] instead.</p>
     Play,
     /// The properties (Props) key.
     Props,
@@ -259,7 +254,7 @@ pub enum Key {
     /// Initiate or continue forward playback at faster than normal speed, or increase speed if already fast forwarding. (<code class="appcommand"><code class="appcommand">APPCOMMAND_MEDIA_FAST_FORWARD</code></code>, <code class="android"><code class="android">KEYCODE_MEDIA_FAST_FORWARD</code></code>)
     MediaFastForward,
     /// Pause the currently playing media. (<code class="appcommand"><code class="appcommand">APPCOMMAND_MEDIA_PAUSE</code></code>, <code class="android"><code class="android">KEYCODE_MEDIA_PAUSE</code></code>)
-    /// <p class="note" role="note">Media controller devices should use this value rather than [`Pause`][Key::Pause] for their pause keys.</p>
+    /// <p class="note" role="note">Media controller devices should use this value rather than [`Pause`][NamedKey::Pause] for their pause keys.</p>
     MediaPause,
     /// Initiate or continue media playback at normal speed, if not currently playing at normal speed. (<code class="appcommand"><code class="appcommand">APPCOMMAND_MEDIA_PLAY</code></code>, <code class="android"><code class="android">KEYCODE_MEDIA_PLAY</code></code>)
     MediaPlay,
@@ -522,7 +517,7 @@ pub enum Key {
     /// Lock or unlock current content or program. (<code class="vk">VK_LOCK</code>)
     Lock,
     /// Show a list of media applications: audio/video players and image viewers. (<code class="vk">VK_APPS</code>)
-    /// <p class="note" role="note">Do not confuse this key value with the Windows' <code class="vk"><code class="vk">VK_APPS</code></code> / <code class="vk"><code class="vk">VK_CONTEXT_MENU</code></code> key, which is encoded as [`ContextMenu`][Key::ContextMenu].</p>
+    /// <p class="note" role="note">Do not confuse this key value with the Windows' <code class="vk"><code class="vk">VK_APPS</code></code> / <code class="vk"><code class="vk">VK_CONTEXT_MENU</code></code> key, which is encoded as [`ContextMenu`][NamedKey::ContextMenu].</p>
     MediaApps,
     /// Audio track key. (<code class="android">KEYCODE_MEDIA_AUDIO_TRACK</code>)
     MediaAudioTrack,
@@ -671,12 +666,10 @@ pub enum Key {
 }
 
 
-impl Display for Key {
+impl Display for NamedKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::Key::*;
+        use self::NamedKey::*;
         match *self {
-            Character(ref s) => write!(f, "{}", s),
-
             Unidentified => f.write_str("Unidentified"),
             Alt => f.write_str("Alt"),
             AltGraph => f.write_str("AltGraph"),
@@ -989,13 +982,12 @@ impl Display for Key {
     }
 }
 
-impl FromStr for Key {
-    type Err = UnrecognizedKeyError;
+impl FromStr for NamedKey {
+    type Err = UnrecognizedNamedKeyError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use crate::Key::*;
+        use crate::NamedKey::*;
         match s {
-            s if is_key_string(s) => Ok(Character(s.to_string())),
             "Unidentified" => Ok(Unidentified),
             "Alt" => Ok(Alt),
             "AltGraph" => Ok(AltGraph),
@@ -1304,39 +1296,19 @@ impl FromStr for Key {
             "F34" => Ok(F34),
             "F35" => Ok(F35),
 
-            _ => Err(UnrecognizedKeyError),
+            _ => Err(UnrecognizedNamedKeyError),
         }
     }
 }
 
 /// Parse from string error, returned when string does not match to any Key variant.
 #[derive(Clone, Debug)]
-pub struct UnrecognizedKeyError;
+pub struct UnrecognizedNamedKeyError;
 
-impl fmt::Display for UnrecognizedKeyError {
+impl fmt::Display for UnrecognizedNamedKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Unrecognized key")
     }
 }
 
-impl Error for UnrecognizedKeyError {}
-
-/// Check if string can be used as a `Key::Character` _keystring_.
-///
-/// This check is simple and is meant to prevents common mistakes like mistyped keynames
-/// (e.g. `Ennter`) from being recognized as characters.
-fn is_key_string(s: &str) -> bool {
-    s.chars().all(|c| !c.is_control()) && s.chars().skip(1).all(|c| !c.is_ascii())
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_is_key_string() {
-        assert!(is_key_string("A"));
-        assert!(!is_key_string("AA"));
-        assert!(!is_key_string("	"));
-    }
-}
+impl Error for UnrecognizedNamedKeyError {}

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -49,12 +49,12 @@ impl<T> ShortcutMatcher<T> {
     /// execute the provided function.
     ///
     /// ```rust
-    /// # use keyboard_types::{Key, KeyboardEvent, Modifiers, ShortcutMatcher};
+    /// # use keyboard_types::{Key, KeyboardEvent, Modifiers, NamedKey, ShortcutMatcher};
     /// # fn do_something() {}
     /// # fn forward_event() {}
     /// # let event = KeyboardEvent {
     /// #     state: keyboard_types::KeyState::Down,
-    /// #     key: Key::Enter,
+    /// #     key: Key::Named(NamedKey::Enter),
     /// #     code: keyboard_types::Code::Enter,
     /// #     location: keyboard_types::Location::Standard,
     /// #     modifiers: Modifiers::empty(),
@@ -65,10 +65,10 @@ impl<T> ShortcutMatcher<T> {
     /// // Shortcuts are tested in-order.
     /// ShortcutMatcher::from_event(event)
     /// // Do something if the Tab key is pressed.
-    /// .shortcut(Modifiers::empty(), Key::Tab, do_something)
+    /// .shortcut(Modifiers::empty(), Key::Named(NamedKey::Tab), do_something)
     /// // If Shift + Tab are pressed do something.
     /// // This is executed because the previous shortcut requires modifiers to be empty.
-    /// .shortcut(Modifiers::SHIFT, Key::Tab, do_something)
+    /// .shortcut(Modifiers::SHIFT, Key::Named(NamedKey::Tab), do_something)
     /// // Instead of named keys letters and other characters can be used.
     /// .shortcut(Modifiers::CONTROL, 'L', do_something)
     /// // Multiple modifiers are combined with bitwise OR (`|`) to form a new mask.
@@ -101,12 +101,12 @@ impl<T> ShortcutMatcher<T> {
     /// This is especially useful for platform specific shortcuts.
     ///
     /// ```rust
-    /// # use keyboard_types::{Key, KeyboardEvent, Modifiers, ShortcutMatcher};
+    /// # use keyboard_types::{Key, KeyboardEvent, Modifiers, NamedKey, ShortcutMatcher};
     /// # fn copy() {}
     /// # fn quit() {}
     /// # let event = KeyboardEvent {
     /// #     state: keyboard_types::KeyState::Down,
-    /// #     key: Key::Enter,
+    /// #     key: Key::Named(NamedKey::Enter),
     /// #     code: keyboard_types::Code::Enter,
     /// #     location: keyboard_types::Location::Standard,
     /// #     modifiers: Modifiers::empty(),

--- a/src/webdriver.rs
+++ b/src/webdriver.rs
@@ -16,7 +16,7 @@
 //!
 //! // The `\u{E029}` code is the WebDriver id for the Numpad divide key.
 //! keyboard_event = state.dispatch_keydown('\u{E050}');
-//! assert_eq!(keyboard_event.key, Key::Shift);
+//! assert_eq!(keyboard_event.key, Key::Named(NamedKey::Shift));
 //! assert_eq!(keyboard_event.code, Code::ShiftRight);
 //! assert_eq!(keyboard_event.location, Location::Right);
 //!
@@ -45,7 +45,7 @@ use std::collections::HashSet;
 
 use unicode_segmentation::UnicodeSegmentation;
 
-use crate::first_char;
+use crate::{first_char, NamedKey};
 use crate::{Code, Key, KeyState, KeyboardEvent, Location, Modifiers};
 use crate::{CompositionEvent, CompositionState};
 
@@ -53,31 +53,31 @@ use crate::{CompositionEvent, CompositionState};
 // normalised (sic) as in british spelling
 fn normalised_key_value(raw_key: char) -> Key {
     match raw_key {
-        '\u{E000}' => Key::Unidentified,
-        '\u{E001}' => Key::Cancel,
-        '\u{E002}' => Key::Help,
-        '\u{E003}' => Key::Backspace,
-        '\u{E004}' => Key::Tab,
-        '\u{E005}' => Key::Clear,
+        '\u{E000}' => Key::Named(NamedKey::Unidentified),
+        '\u{E001}' => Key::Named(NamedKey::Cancel),
+        '\u{E002}' => Key::Named(NamedKey::Help),
+        '\u{E003}' => Key::Named(NamedKey::Backspace),
+        '\u{E004}' => Key::Named(NamedKey::Tab),
+        '\u{E005}' => Key::Named(NamedKey::Clear),
         // FIXME: spec says "Return"
-        '\u{E006}' => Key::Enter,
-        '\u{E007}' => Key::Enter,
-        '\u{E008}' => Key::Shift,
-        '\u{E009}' => Key::Control,
-        '\u{E00A}' => Key::Alt,
-        '\u{E00B}' => Key::Pause,
-        '\u{E00C}' => Key::Escape,
+        '\u{E006}' => Key::Named(NamedKey::Enter),
+        '\u{E007}' => Key::Named(NamedKey::Enter),
+        '\u{E008}' => Key::Named(NamedKey::Shift),
+        '\u{E009}' => Key::Named(NamedKey::Control),
+        '\u{E00A}' => Key::Named(NamedKey::Alt),
+        '\u{E00B}' => Key::Named(NamedKey::Pause),
+        '\u{E00C}' => Key::Named(NamedKey::Escape),
         '\u{E00D}' => Key::Character(" ".to_string()),
-        '\u{E00E}' => Key::PageUp,
-        '\u{E00F}' => Key::PageDown,
-        '\u{E010}' => Key::End,
-        '\u{E011}' => Key::Home,
-        '\u{E012}' => Key::ArrowLeft,
-        '\u{E013}' => Key::ArrowUp,
-        '\u{E014}' => Key::ArrowRight,
-        '\u{E015}' => Key::ArrowDown,
-        '\u{E016}' => Key::Insert,
-        '\u{E017}' => Key::Delete,
+        '\u{E00E}' => Key::Named(NamedKey::PageUp),
+        '\u{E00F}' => Key::Named(NamedKey::PageDown),
+        '\u{E010}' => Key::Named(NamedKey::End),
+        '\u{E011}' => Key::Named(NamedKey::Home),
+        '\u{E012}' => Key::Named(NamedKey::ArrowLeft),
+        '\u{E013}' => Key::Named(NamedKey::ArrowUp),
+        '\u{E014}' => Key::Named(NamedKey::ArrowRight),
+        '\u{E015}' => Key::Named(NamedKey::ArrowDown),
+        '\u{E016}' => Key::Named(NamedKey::Insert),
+        '\u{E017}' => Key::Named(NamedKey::Delete),
         '\u{E018}' => Key::Character(";".to_string()),
         '\u{E019}' => Key::Character("=".to_string()),
         '\u{E01A}' => Key::Character("0".to_string()),
@@ -96,34 +96,34 @@ fn normalised_key_value(raw_key: char) -> Key {
         '\u{E027}' => Key::Character("-".to_string()),
         '\u{E028}' => Key::Character(".".to_string()),
         '\u{E029}' => Key::Character("/".to_string()),
-        '\u{E031}' => Key::F1,
-        '\u{E032}' => Key::F2,
-        '\u{E033}' => Key::F3,
-        '\u{E034}' => Key::F4,
-        '\u{E035}' => Key::F5,
-        '\u{E036}' => Key::F6,
-        '\u{E037}' => Key::F7,
-        '\u{E038}' => Key::F8,
-        '\u{E039}' => Key::F9,
-        '\u{E03A}' => Key::F10,
-        '\u{E03B}' => Key::F11,
-        '\u{E03C}' => Key::F12,
-        '\u{E03D}' => Key::Meta,
-        '\u{E040}' => Key::ZenkakuHankaku,
-        '\u{E050}' => Key::Shift,
-        '\u{E051}' => Key::Control,
-        '\u{E052}' => Key::Alt,
-        '\u{E053}' => Key::Meta,
-        '\u{E054}' => Key::PageUp,
-        '\u{E055}' => Key::PageDown,
-        '\u{E056}' => Key::End,
-        '\u{E057}' => Key::Home,
-        '\u{E058}' => Key::ArrowLeft,
-        '\u{E059}' => Key::ArrowUp,
-        '\u{E05A}' => Key::ArrowRight,
-        '\u{E05B}' => Key::ArrowDown,
-        '\u{E05C}' => Key::Insert,
-        '\u{E05D}' => Key::Delete,
+        '\u{E031}' => Key::Named(NamedKey::F1),
+        '\u{E032}' => Key::Named(NamedKey::F2),
+        '\u{E033}' => Key::Named(NamedKey::F3),
+        '\u{E034}' => Key::Named(NamedKey::F4),
+        '\u{E035}' => Key::Named(NamedKey::F5),
+        '\u{E036}' => Key::Named(NamedKey::F6),
+        '\u{E037}' => Key::Named(NamedKey::F7),
+        '\u{E038}' => Key::Named(NamedKey::F8),
+        '\u{E039}' => Key::Named(NamedKey::F9),
+        '\u{E03A}' => Key::Named(NamedKey::F10),
+        '\u{E03B}' => Key::Named(NamedKey::F11),
+        '\u{E03C}' => Key::Named(NamedKey::F12),
+        '\u{E03D}' => Key::Named(NamedKey::Meta),
+        '\u{E040}' => Key::Named(NamedKey::ZenkakuHankaku),
+        '\u{E050}' => Key::Named(NamedKey::Shift),
+        '\u{E051}' => Key::Named(NamedKey::Control),
+        '\u{E052}' => Key::Named(NamedKey::Alt),
+        '\u{E053}' => Key::Named(NamedKey::Meta),
+        '\u{E054}' => Key::Named(NamedKey::PageUp),
+        '\u{E055}' => Key::Named(NamedKey::PageDown),
+        '\u{E056}' => Key::Named(NamedKey::End),
+        '\u{E057}' => Key::Named(NamedKey::Home),
+        '\u{E058}' => Key::Named(NamedKey::ArrowLeft),
+        '\u{E059}' => Key::Named(NamedKey::ArrowUp),
+        '\u{E05A}' => Key::Named(NamedKey::ArrowRight),
+        '\u{E05B}' => Key::Named(NamedKey::ArrowDown),
+        '\u{E05C}' => Key::Named(NamedKey::Insert),
+        '\u{E05D}' => Key::Named(NamedKey::Delete),
         _ => Key::Character(raw_key.to_string()),
     }
 }
@@ -293,10 +293,10 @@ fn key_location(raw_key: char) -> Location {
 
 fn get_modifier(key: &Key) -> Modifiers {
     match key {
-        Key::Alt => Modifiers::ALT,
-        Key::Shift => Modifiers::SHIFT,
-        Key::Control => Modifiers::CONTROL,
-        Key::Meta => Modifiers::META,
+        Key::Named(NamedKey::Alt) => Modifiers::ALT,
+        Key::Named(NamedKey::Shift) => Modifiers::SHIFT,
+        Key::Named(NamedKey::Control) => Modifiers::CONTROL,
+        Key::Named(NamedKey::Meta) => Modifiers::META,
         _ => Modifiers::empty(),
     }
 }
@@ -432,20 +432,22 @@ pub fn send_keys(text: &str) -> Vec<Event> {
         // values from <https://www.w3.org/TR/uievents-key/#keys-modifier>
         matches!(
             normalised_key_value(first_char(text)),
-            Key::Alt
-                | Key::AltGraph
-                | Key::CapsLock
-                | Key::Control
-                | Key::Fn
-                | Key::FnLock
-                | Key::Meta
-                | Key::NumLock
-                | Key::ScrollLock
-                | Key::Shift
-                | Key::Symbol
-                | Key::SymbolLock
-                | Key::Hyper
-                | Key::Super
+            Key::Named(
+                NamedKey::Alt
+                    | NamedKey::AltGraph
+                    | NamedKey::CapsLock
+                    | NamedKey::Control
+                    | NamedKey::Fn
+                    | NamedKey::FnLock
+                    | NamedKey::Meta
+                    | NamedKey::NumLock
+                    | NamedKey::ScrollLock
+                    | NamedKey::Shift
+                    | NamedKey::Symbol
+                    | NamedKey::SymbolLock
+                    | NamedKey::Hyper
+                    | NamedKey::Super
+            )
         )
     }
 


### PR DESCRIPTION
This makes most of the key `Copy`, and allows other crates like Winit to more easily use their own string types.

See https://github.com/rust-windowing/winit/issues/2995 and https://github.com/rust-windowing/winit/pull/3143 for discussion on a similar change in Winit.

Part of https://github.com/pyfisch/keyboard-types/issues/19.