### PR TITLE
Add `PartialOrd` and `Ord` implementations

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -64,7 +64,7 @@ use std::error::Error;
 ///
 /// Specification:
 /// <https://w3c.github.io/uievents-key/>
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum Key {
@@ -164,7 +164,7 @@ use std::error::Error;
 ///
 /// Specification:
 /// <https://w3c.github.io/uievents-code/>
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum Code {""", file=file)

--- a/src/code.rs
+++ b/src/code.rs
@@ -14,7 +14,7 @@ use std::error::Error;
 ///
 /// Specification:
 /// <https://w3c.github.io/uievents-code/>
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum Code {

--- a/src/key.rs
+++ b/src/key.rs
@@ -10,7 +10,7 @@ use std::error::Error;
 ///
 /// Specification:
 /// <https://w3c.github.io/uievents-key/>
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub enum Key {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub mod webdriver;
 use serde::{Deserialize, Serialize};
 
 /// Describes the state the key is in.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum KeyState {
     /// Key is pressed.
@@ -40,7 +40,7 @@ pub enum KeyState {
 }
 
 /// Keyboard events are issued for all pressed and released keys.
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct KeyboardEvent {
     /// Whether the key is pressed or released.
@@ -61,7 +61,7 @@ pub struct KeyboardEvent {
 }
 
 /// Describes the state of a composition session.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CompositionState {
     /// In JS: "compositionstart" event.
@@ -93,7 +93,7 @@ impl fmt::Display for CompositionState {
 /// A composition session is always started by a [`CompositionState::Start`]
 /// event followed my zero or more [`CompositionState::Update`] events
 /// and terminated by a single [`CompositionState::End`] event.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CompositionEvent {
     /// Describes the event kind.

--- a/src/location.rs
+++ b/src/location.rs
@@ -1,6 +1,6 @@
 /// The location attribute contains an indication of the logical location
 /// of the key on the device.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Location {
     /// The key activation MUST NOT be distinguished as the left or right

--- a/src/webdriver.rs
+++ b/src/webdriver.rs
@@ -401,7 +401,7 @@ impl KeyInputState {
 /// Either a [`KeyboardEvent`] or a [`CompositionEvent`].
 ///
 /// Returned by the [`send_keys`] function.
-#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Event {
     Keyboard(KeyboardEvent),


### PR DESCRIPTION
Allows using these types in `BTreeMap`/`BTreeSet`.

Note that we do not guarantee anything about the ordering between SemVer-compatible versions of the crate.

See also:
- https://github.com/rust-windowing/winit/pull/2918
- https://github.com/rust-windowing/winit/pull/2998
- https://github.com/rust-windowing/winit/pull/3796

(And https://github.com/rust-windowing/winit/pull/3866 for the case where `PartialOrd`/`Ord` wouldn't make sense).

Part of #19.