### PR TITLE
Change `KeyState`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,6 @@
 
 #![warn(clippy::doc_markdown)]
 
-use std::fmt;
-
 pub use crate::code::{Code, UnrecognizedCodeError};
 pub use crate::key::{Key, UnrecognizedKeyError};
 pub use crate::location::Location;
@@ -37,6 +35,20 @@ pub enum KeyState {
     ///
     /// In JS: "keyup event".
     Up,
+}
+
+impl KeyState {
+    /// The [type] name of the corresponding key event.
+    ///
+    /// This is either `"keydown"` or `"keyup"`.
+    ///
+    /// [type]: https://w3c.github.io/uievents/#events-keyboard-types
+    pub const fn event_type(self) -> &'static str {
+        match self {
+            Self::Down => "keydown",
+            Self::Up => "keyup",
+        }
+    }
 }
 
 /// Keyboard events are issued for all pressed and released keys.
@@ -119,15 +131,6 @@ pub struct CompositionEvent {
     pub state: CompositionState,
     /// Current composition data. May be empty.
     pub data: String,
-}
-
-impl fmt::Display for KeyState {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            KeyState::Down => f.write_str("keydown"),
-            KeyState::Up => f.write_str("keyup"),
-        }
-    }
 }
 
 impl Key {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,16 @@ impl KeyState {
             Self::Up => "keyup",
         }
     }
+
+    /// True if the key is pressed down.
+    pub const fn is_down(self) -> bool {
+        matches!(self, Self::Down)
+    }
+
+    /// True if the key is released.
+    pub const fn is_up(self) -> bool {
+        matches!(self, Self::Up)
+    }
 }
 
 /// Keyboard events are issued for all pressed and released keys.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,17 +23,23 @@ pub mod webdriver;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// Describes the state the key is in.
+/// Describes the state a key is in.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum KeyState {
-    /// Key is pressed.
+    /// The key is pressed down.
     ///
-    /// In JS: "keydown" event firing.
+    /// Often emitted in a [keydown] event, see also [the MDN documentation][mdn] on that.
+    ///
+    /// [keydown]: https://w3c.github.io/uievents/#event-type-keydown
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/Element/keydown_event
     Down,
-    /// Key is released.
+    /// The key is not pressed / was just released.
     ///
-    /// In JS: "keyup event".
+    /// Often emitted in a [keyup] event, see also [the MDN documentation][mdn] on that.
+    ///
+    /// [keyup]: https://w3c.github.io/uievents/#event-type-keyup
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/Element/keyup_event
     Up,
 }
 

--- a/src/shortcuts.rs
+++ b/src/shortcuts.rs
@@ -85,7 +85,7 @@ impl<T> ShortcutMatcher<T> {
             return self;
         }
         if modifiers == self.modifiers && key.match_key(&self.key) {
-            if self.state == KeyState::Down {
+            if self.state.is_down() {
                 self.value = Some(f());
             }
             self.matched = true;


### PR DESCRIPTION
Remove `Display` impl, rename variants and add helper methods, see each commit for details.

The motivation is to make this match [`winit::event::ElementState`](https://docs.rs/winit/0.30.5/winit/event/enum.ElementState.html).

Unsure about the helper method names, whether `is_pressed` or `pressed` is cleaner? I went with `is_pressed` to match what's used in the wild for e.g. Bevy's [`ButtonState`](https://docs.rs/bevy/0.15.0/bevy/input/enum.ButtonState.html), and since it also more closely matches Rust conventions on enums (`is_some`, `is_poisoned`, `is_ne`, ...). But that's inconsistent with e.g. `Modifiers::shift` (so maybe we should change the latter too?).