### PR TITLE
Bump MSRV to 1.61

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - "1.60"
+          - "1.61"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/pyfisch/keyboard-types"
 keywords = ["keyboard", "input", "event", "webdriver"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.61"
 
 [features]
 default = ["serde", "webdriver"]


### PR DESCRIPTION
Half of #47.

I have verified that `keyboard-types` does actual compile on `1.61`