### PR TITLE
Appease clippy

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -55,6 +55,7 @@ def convert_key(text, file):
     print("""
 // AUTO GENERATED CODE - DO NOT EDIT
 #![cfg_attr(rustfmt, rustfmt_skip)]
+#![allow(clippy::doc_markdown)]
 
 use std::fmt::{self, Display};
 use std::str::FromStr;
@@ -151,6 +152,7 @@ def convert_code(text, file):
     print("""
 // AUTO GENERATED CODE - DO NOT EDIT
 #![cfg_attr(rustfmt, rustfmt_skip)]
+#![allow(clippy::doc_markdown)]
 
 use std::fmt::{self, Display};
 use std::str::FromStr;

--- a/src/code.rs
+++ b/src/code.rs
@@ -1,6 +1,7 @@
 
 // AUTO GENERATED CODE - DO NOT EDIT
 #![cfg_attr(rustfmt, rustfmt_skip)]
+#![allow(clippy::doc_markdown)]
 
 use std::fmt::{self, Display};
 use std::str::FromStr;

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,6 +1,7 @@
 
 // AUTO GENERATED CODE - DO NOT EDIT
 #![cfg_attr(rustfmt, rustfmt_skip)]
+#![allow(clippy::doc_markdown)]
 
 use std::fmt::{self, Display};
 use std::str::FromStr;
@@ -18,7 +19,7 @@ pub enum Key {
     /// taking into account the user’s current locale setting, modifier state,
     /// and any system-level keyboard mapping overrides that are in effect.
     Character(String),
-    
+
     /// This key value is used when an implementation is unable to
     /// identify another key value, due to either hardware,
     /// platform, or software constraints.
@@ -672,7 +673,7 @@ impl Display for Key {
         use self::Key::*;
         match *self {
             Character(ref s) => write!(f, "{}", s),
-    
+
             Unidentified => f.write_str("Unidentified"),
             Alt => f.write_str("Alt"),
             AltGraph => f.write_str("AltGraph"),
@@ -1336,4 +1337,3 @@ mod test {
         assert!(!is_key_string("	"));
     }
 }
-    

--- a/src/location.rs
+++ b/src/location.rs
@@ -4,7 +4,7 @@
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Location {
     /// The key activation MUST NOT be distinguished as the left or right
-    /// version of the key, and (other than the NumLock key) did not
+    /// version of the key, and (other than the `NumLock` key) did not
     /// originate from the numeric keypad (or did not originate with a
     /// virtual key corresponding to the numeric keypad).
     Standard = 0x00,
@@ -16,7 +16,7 @@ pub enum Location {
     Right = 0x02,
     /// The key activation originated on the numeric keypad or with a virtual
     /// key corresponding to the numeric keypad (when there is more than one
-    /// possible location for this key). Note that the NumLock key should
+    /// possible location for this key). Note that the `NumLock` key should
     /// always be encoded with a location of `Location::Standard`.
     Numpad = 0x03,
 }


### PR DESCRIPTION
Fixes https://github.com/pyfisch/keyboard-types/issues/47.

I chose to ignore the lints, since the documentation is auto-generated, and thus hard to control.