### PR TITLE
Note alternative names of `Code::Backquote` and `Code::Quote`

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -71,6 +71,14 @@ def print_from_str_entries(display, file):
         print(" => Ok({0}),".format(key), file=file)
 
 
+def add_comment_to(display, key, comment):
+    for (i, [found_key, doc_comment, alternatives]) in enumerate(display):
+        if found_key != key:
+            continue
+        doc_comment = doc_comment + "\n" + comment
+        display[i] = [found_key, doc_comment, alternatives]
+
+
 def add_alternative_for(display, key, alternative):
     for [found_key, doc_comment, alternatives] in display:
         if found_key != key:
@@ -235,6 +243,9 @@ pub enum Code {""", file=file)
             'Non-standard code value supported by Chromium.',
             []
         ])
+
+    add_comment_to(display, 'Backquote', 'This is also called a backtick or grave.')
+    add_comment_to(display, 'Quote', 'This is also called an apostrophe.')
 
     add_alternative_for(display, 'MetaLeft', 'OSLeft')
     add_alternative_for(display, 'MetaRight', 'OSRight')

--- a/src/code.rs
+++ b/src/code.rs
@@ -20,6 +20,7 @@ use std::error::Error;
 #[non_exhaustive]
 pub enum Code {
     /// <kbd>`~</kbd> on a US keyboard. This is the <kbd>半角/全角/漢字</kbd> (<span class="unicode">hankaku/zenkaku/kanji</span>) key on Japanese keyboards
+    /// This is also called a backtick or grave.
     Backquote,
     /// Used for both the US <kbd>\|</kbd> (on the 101-key layout) and also for the key
     /// located between the <kbd>"</kbd> and <kbd>Enter</kbd> keys on row C of the 102-,
@@ -127,6 +128,7 @@ pub enum Code {
     /// <kbd>.&gt;</kbd> on a US keyboard.
     Period,
     /// <kbd>'"</kbd> on a US keyboard.
+    /// This is also called an apostrophe.
     Quote,
     /// <kbd>;:</kbd> on a US keyboard.
     Semicolon,


### PR DESCRIPTION
This is useful to have when searching.

I filed https://github.com/w3c/uievents-code/pull/44 to get the backquote part upstream, but that hasn't seen much movement, so I thought I'd fix it here for now.