### PR TITLE
Remove `serde` and `webdriver` from `default` features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-      # Default features
-      - run: cargo check --all-targets
-      - run: cargo test
+      # All features
+      - run: cargo check --all-targets --all-features
+      - run: cargo test --all-features
       # No default features
       - run: cargo check --all-targets --no-default-features
       - run: cargo test --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.61"
 [features]
 default = []
 serde = ["dep:serde", "bitflags/serde"]
-webdriver = ["unicode-segmentation"]
+webdriver = ["dep:unicode-segmentation"]
 
 [dependencies]
 bitflags = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 rust-version = "1.61"
 
 [features]
-default = ["serde", "webdriver"]
+default = []
 serde = ["dep:serde", "bitflags/serde"]
 webdriver = ["unicode-segmentation"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ webdriver = ["unicode-segmentation"]
 bitflags = "2"
 serde = { version = "1.0.0", optional = true, features = ["derive"] }
 unicode-segmentation = { version = "1.2.0", optional = true }
+
+[package.metadata.docs.rs]
+all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 //! input in a cross-platform way.
 
 #![warn(clippy::doc_markdown)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use std::fmt;
 


### PR DESCRIPTION
I suspect most users will not want these enabled, but it's very easy to accidentally do so when depending on `keyboard-types`. Not that it's a _big_ problem, because both deps are small and trusted, but it's still a bit annoying.

I've also enabled `doc_auto_cfg` to ensure that the docs on docs.rs make it clear that feature flags are required to enable these.