### PR TITLE
Note that "super" is often emitted as `Meta` on Linux

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -120,6 +120,8 @@ pub enum NamedKey {""", file=file)
             []
         ])
 
+    add_comment_to(display, 'Meta', 'In Linux (XKB) terminology, this is often referred to as "Super".')
+
     emit_enum_entries(display, file)
     print("}", file=file)
 
@@ -228,6 +230,8 @@ pub enum Code {""", file=file)
 
     add_comment_to(display, 'Backquote', 'This is also called a backtick or grave.')
     add_comment_to(display, 'Quote', 'This is also called an apostrophe.')
+    add_comment_to(display, 'MetaLeft', 'In Linux (XKB) terminology, this is often referred to as the left "Super".')
+    add_comment_to(display, 'MetaRight', 'In Linux (XKB) terminology, this is often referred to as the right "Super".')
 
     add_alternative_for(display, 'MetaLeft', 'OSLeft')
     add_alternative_for(display, 'MetaRight', 'OSRight')

--- a/src/code.rs
+++ b/src/code.rs
@@ -154,8 +154,10 @@ pub enum Code {
     /// <kbd>Enter</kbd> or <kbd>↵</kbd>. Labelled <kbd>Return</kbd> on Apple keyboards.
     Enter,
     /// The Windows, <kbd>⌘</kbd>, <kbd>Command</kbd> or other OS symbol key.
+    /// In Linux (XKB) terminology, this is often referred to as the left "Super".
     MetaLeft,
     /// The Windows, <kbd>⌘</kbd>, <kbd>Command</kbd> or other OS symbol key.
+    /// In Linux (XKB) terminology, this is often referred to as the right "Super".
     MetaRight,
     /// <kbd>Shift</kbd> or <kbd>⇧</kbd>
     ShiftLeft,

--- a/src/named_key.rs
+++ b/src/named_key.rs
@@ -40,6 +40,7 @@ pub enum NamedKey {
     FnLock,
     /// The <kbd>Meta</kbd> key, to enable meta modifier function for interpreting concurrent or subsequent keyboard input.
     /// This key value is used for the <q>Windows Logo</q> key and the Apple <kbd>Command</kbd> or <kbd>⌘</kbd> key.
+    /// In Linux (XKB) terminology, this is often referred to as "Super".
     Meta,
     /// The <kbd>NumLock</kbd> or Number Lock key, to toggle numpad mode function for interpreting subsequent keyboard input.
     NumLock,


### PR DESCRIPTION
From discussion in https://github.com/rust-windowing/winit/pull/4018#discussion_r1865821387. Happy to take suggestions on the wording.

Related to https://github.com/pyfisch/keyboard-types/pull/49.