### PR TITLE
Initial `no_std` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,14 @@ edition = "2021"
 rust-version = "1.61"
 
 [features]
-default = []
+default = ["std"]
 serde = ["dep:serde", "bitflags/serde"]
-webdriver = ["dep:unicode-segmentation"]
+std = ["serde?/std"]
+webdriver = ["dep:unicode-segmentation", "std"]
 
 [dependencies]
 bitflags = "2"
-serde = { version = "1.0.0", optional = true, features = ["derive"] }
+serde = { version = "1.0.0", optional = true, default-features = false, features = ["derive"] }
 unicode-segmentation = { version = "1.2.0", optional = true }
 
 [package.metadata.docs.rs]

--- a/convert.py
+++ b/convert.py
@@ -98,8 +98,9 @@ def convert_key(text, file):
 #![allow(clippy::doc_markdown)]
 #![allow(deprecated)]
 
-use std::fmt::{self, Display};
-use std::str::FromStr;
+use core::fmt::{self, Display};
+use core::str::FromStr;
+#[cfg(feature = "std")]
 use std::error::Error;
 
 /// Key represents the meaning of a keypress.
@@ -158,6 +159,7 @@ impl fmt::Display for UnrecognizedNamedKeyError {
     }
 }
 
+#[cfg(feature = "std")]
 impl Error for UnrecognizedNamedKeyError {}""", file=file)
 
 
@@ -168,8 +170,9 @@ def convert_code(text, file):
 #![allow(clippy::doc_markdown)]
 #![allow(deprecated)]
 
-use std::fmt::{self, Display};
-use std::str::FromStr;
+use core::fmt::{self, Display};
+use core::str::FromStr;
+#[cfg(feature = "std")]
 use std::error::Error;
 
 /// Code is the physical position of a key.
@@ -274,6 +277,7 @@ impl fmt::Display for UnrecognizedCodeError {
     }
 }
 
+#[cfg(feature = "std")]
 impl Error for UnrecognizedCodeError {}""", file=file)
 
 

--- a/src/code.rs
+++ b/src/code.rs
@@ -4,8 +4,9 @@
 #![allow(clippy::doc_markdown)]
 #![allow(deprecated)]
 
-use std::fmt::{self, Display};
-use std::str::FromStr;
+use core::fmt::{self, Display};
+use core::str::FromStr;
+#[cfg(feature = "std")]
 use std::error::Error;
 
 /// Code is the physical position of a key.
@@ -934,4 +935,5 @@ impl fmt::Display for UnrecognizedCodeError {
     }
 }
 
+#[cfg(feature = "std")]
 impl Error for UnrecognizedCodeError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,11 @@
 
 #![warn(clippy::doc_markdown)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 
+extern crate alloc;
+
+use alloc::string::{String, ToString};
 use core::fmt;
 use core::str::FromStr;
 

--- a/src/named_key.rs
+++ b/src/named_key.rs
@@ -4,8 +4,9 @@
 #![allow(clippy::doc_markdown)]
 #![allow(deprecated)]
 
-use std::fmt::{self, Display};
-use std::str::FromStr;
+use core::fmt::{self, Display};
+use core::str::FromStr;
+#[cfg(feature = "std")]
 use std::error::Error;
 
 /// Key represents the meaning of a keypress.
@@ -1311,4 +1312,5 @@ impl fmt::Display for UnrecognizedNamedKeyError {
     }
 }
 
+#[cfg(feature = "std")]
 impl Error for UnrecognizedNamedKeyError {}


### PR DESCRIPTION
Since `core::error` isn't in Rust until 1.81, we can't use it and so we only derive `Error` for the error types when building with the `std` feature.

Also, `webdriver` implies `std` as well (for now?).