### PR TITLE
Fix typo, check in CI going forward

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,12 @@ jobs:
       - run: cargo doc --all-features --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: '-D warnings'
+
+  # If this fails, consider changing your text or adding something to .typos.toml.
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: check typos
+        uses: crate-ci/typos@v1.30.2

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,22 @@
+# See the configuration reference at
+# https://github.com/crate-ci/typos/blob/master/docs/reference.md
+
+# Corrections take the form of a key/value pair. The key is the incorrect word
+# and the value is the correct word. If the key and value are the same, the
+# word is treated as always correct. If the value is an empty string, the word
+# is treated as always incorrect.
+
+# Match Identifier - Case Sensitive
+[default.extend-identifiers]
+
+# Match Inside a Word - Case Insensitive
+[default.extend-words]
+
+[files]
+# Include .github, .cargo, etc.
+ignore-hidden = false
+extend-exclude = [
+    # /.git isn't in .gitignore, because git never tracks it.
+    # Typos doesn't know that, though.
+    "/.git",
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,7 @@ pub struct CompositionEvent {
     pub data: String,
 }
 
-/// The value recieved from the keypress.
+/// The value received from the keypress.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Key {


### PR DESCRIPTION
This pins a version of the typos check which means someone would need to periodically update it. That prevents people from having to fix typos unrelated to their changes, should there be new things found by a future update of the typos check.