### PR TITLE
webdriver: Do not unwrap when clear `undo_actions`

### DIFF
--- a/src/webdriver.rs
+++ b/src/webdriver.rs
@@ -514,3 +514,29 @@ pub fn send_keys(text: &str) -> Vec<Event> {
     state.clear(&mut undo_actions, &mut result);
     result
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::vec;
+
+    #[test]
+    fn test_send_key_with_shift() {
+        let result: Vec<(KeyState, Key)> = send_keys("\u{e008}y")
+            .iter()
+            .map(|e| match e {
+                Event::Keyboard(key_event) => (key_event.state, key_event.key.clone()),
+                _ => unreachable!("Unexpected event"),
+            })
+            .collect();
+
+        let expected = vec![
+            (KeyState::Down, Key::Named(NamedKey::Shift)),
+            (KeyState::Up, Key::Named(NamedKey::Shift)),
+            (KeyState::Down, Key::Character("y".to_string())),
+            (KeyState::Up, Key::Character("y".to_string())),
+        ];
+
+        assert_eq!(result, expected);
+    }
+}

--- a/src/webdriver.rs
+++ b/src/webdriver.rs
@@ -381,7 +381,11 @@ impl KeyInputState {
         let mut actions: Vec<_> = undo_actions.drain().collect();
         actions.sort_unstable();
         for action in actions {
-            result.push(self.dispatch_keyup(action).unwrap().into());
+            // When we `dispatch_typeable`, we may have already dispatched keyup
+            // but did not update `undo_actions`.
+            if let Some(event) = self.dispatch_keyup(action) {
+                result.push(event.into());
+            }
         }
         assert!(undo_actions.is_empty());
     }


### PR DESCRIPTION
When we call https://github.com/rust-windowing/keyboard-types/blob/24446d6fe974bca4303affd07072939f4a7aab6f/src/webdriver.rs#L432 with `"\u{e008}y"`, we would always end up with panic. 

We should avoid unwarp here.

See: https://github.com/servo/servo/issues/41007#issuecomment-3601010846